### PR TITLE
latinize.c: generate ASCII-only output

### DIFF
--- a/src/latinize.c
+++ b/src/latinize.c
@@ -29,7 +29,7 @@ int latinize(lua_State *l) {
   }
 
   // Create transliterator
-  DEF_UTF16_LITERAL(translit_id, "Any-Latin; Latin-ASCII");
+  DEF_UTF16_LITERAL(translit_id, "Any-Latin; Latin-ASCII; [\\u0080-\\u7fff] remove");
   UErrorCode status = U_ZERO_ERROR;
   UTransliterator * trans = utrans_openU(translit_id, -1, UTRANS_FORWARD, NULL, 0, NULL, &status);
 


### PR DESCRIPTION
Drop all non-ASCII characters from the transliteration. This ensures our output is ASCII.